### PR TITLE
Updating GKE Cluster's main-node base image (#555)

### DIFF
--- a/prombench/manifests/cluster_gke.yaml
+++ b/prombench/manifests/cluster_gke.yaml
@@ -9,7 +9,7 @@ cluster:
     initialnodecount: 1
     config:
       machinetype: n1-standard-4
-      imagetype: COS
+      imagetype: COS_CONTAINERD
       disksizegb: 300
       labels:
         node-name: main-node


### PR DESCRIPTION
Google has deprectated the use of docker based images (https://cloud.google.com/kubernetes-engine/docs/deprecations/docker-containerd). Similar Commit: 92225dbf485861efd3706f5444bfec4bf1ec7a5a